### PR TITLE
Add Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ SimpleMap looks for certain column headers to know how to process a table.  Thes
 * `Feature`: Use a custom icon, as defined by a simple map settings table. This field is required in order to render a polygon.
 * `Fill Color`: A hex value to apply to the feature shape's fill color.
 * `Border Color`: A hex value to apply to the feature shape's border color.
+* `Overlay Content`: An HTML block that is rendered when a feature is hovered over.
 
 ### SimpleMapSettings Columns
 
@@ -32,6 +33,7 @@ Below are the valid setting names:
 
 * `Icons`: an embedded table (see the `Custom Icons` section) which defines custom icons for use by markers in a SimpleMap.
 * `Feature Collection JSON`: A JSON string which contains a [GeoJSON Feature Collection](https://datatracker.ietf.org/doc/html/rfc7946#section-3.3).  Feature IDs can be referenced by map data.
+* `Overlay Default`: An HTML block that is rendered in the overlay pane when no element has been selected. This must be present in order to render an overlay pane.
 
 #### Icon Columns
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Below are the valid setting names:
 
 * `Icons`: an embedded table (see the `Custom Icons` section) which defines custom icons for use by markers in a SimpleMap.
 * `Feature Collection JSON`: A JSON string which contains a [GeoJSON Feature Collection](https://datatracker.ietf.org/doc/html/rfc7946#section-3.3).  Feature IDs can be referenced by map data.
+* `Overlay Title`: An optional string which, if set, will render before any content on the overlay pane as a title.
 * `Overlay Default`: An HTML block that is rendered in the overlay pane when no element has been selected. This must be present in order to render an overlay pane.
 
 #### Icon Columns

--- a/resources/ext.simplemaps/simplemaps.css
+++ b/resources/ext.simplemaps/simplemaps.css
@@ -2,3 +2,13 @@ div.simpleMap {
 	height: 300px;
 	width: 100%;
 }
+
+div.simpleMapOverlay {
+	padding: 6px 8px;
+	font: 14px/16px Arial, Helvetica, sans-serif;
+	background: white;
+	background: rgba(255,255,255,0.8);
+	box-shadow: 0 0 15px rgba(0,0,0,0.2);
+	border-radius: 5px;
+	min-width: 200px;
+}

--- a/resources/ext.simplemaps/simplemaps.js
+++ b/resources/ext.simplemaps/simplemaps.js
@@ -114,6 +114,7 @@
 			'icons',
 			'featureCollectionJson',
 			'overlayDefault',
+			'overlayTitle',
 		]);
 	}
 
@@ -254,6 +255,7 @@
 			icons: {},
 			features: {},
 			overlayDefault: null,
+			overlayTitle: '',
 		};
 		if (fieldExists(fieldMap.icons, rows)) {
 			settings.icons = loadIconsFromIconsTable(getFirstChildTable(getSettingFromRows(fieldMap.icons, rows)));
@@ -263,6 +265,9 @@
 		}
 		if (fieldExists(fieldMap.overlayDefault, rows)) {
 			settings.overlayDefault = getSettingFromRows(fieldMap.overlayDefault, rows).innerHTML;
+		}
+		if (fieldExists(fieldMap.overlayTitle, rows)) {
+			settings.overlayTitle = getSettingFromRows(fieldMap.overlayTitle, rows).textContent.trim();
 		}
 		return settings;
 	}
@@ -353,7 +358,7 @@
 		overlayPane.update();
 	}
 
-	function generateOverlayControl(defaultContent) {
+	function generateOverlayControl(defaultContent, title) {
 		var overlay = L.control();
 		overlay._div = L.DomUtil.create('div', 'simpleMapOverlay');
 		overlay.onAdd = function (map) {
@@ -361,7 +366,9 @@
 			return this._div;
 		};
 		overlay.update = function (overlayContent) {
-			this._div.innerHTML = overlayContent ? overlayContent : defaultContent;
+			var titleHtml = title ? '<h1>' + title + '</h1>' : '';
+			var contentHtml = (overlayContent ? overlayContent : defaultContent)
+			this._div.innerHTML = titleHtml + contentHtml;
 		};
 		return overlay;
 	}
@@ -406,10 +413,11 @@
 			var icons = getLocalSetting('icons');
 			var features = getLocalSetting('features');
 			var overlayDefault = getLocalSetting('overlayDefault');
+			var overlayTitle = getLocalSetting('overlayTitle');
 			var markers = getMarkersFromMapTable(mapTable);
 			var latLngs = getLatLngsFromMarkers(markers, features);
 			var bounds = new L.LatLngBounds(latLngs);
-			var overlay = generateOverlayControl(overlayDefault)
+			var overlay = generateOverlayControl(overlayDefault, overlayTitle)
 			if (overlayDefault) {
 				overlay.addTo(simpleMap);
 			}

--- a/resources/ext.simplemaps/simplemaps.js
+++ b/resources/ext.simplemaps/simplemaps.js
@@ -272,6 +272,8 @@
 	function hasLatLng(marker) {
 		return !isNaN(marker.lat)
 			&& !isNaN(marker.lng)
+			&& marker.lat !== null
+			&& marker.lng !== null
 			&& marker.lat !== ''
 			&& marker.lng !== '';
 	}
@@ -287,8 +289,7 @@
 				latLngs.push([marker.lat, marker.lng]);
 			};
 			if (hasFeature(marker, features)) {
-				console.log(features[marker.feature].geometry.coordinates[0]);
-				latLngs.push(...features[marker.feature].geometry.coordinates[0])
+				latLngs.push(...L.GeoJSON.coordsToLatLngs(features[marker.feature].geometry.coordinates[0]));
 			}
 			return latLngs;
 		});


### PR DESCRIPTION
This PR adds a new `overlay` feature to SimpleMaps, allowing markers to have an overlay that is rendered when a user hovers their mouse on a marker feature.

This adds two new local settings:

* `Overlay Title`
* `Overlay Default`

Which determine map-wide content for the overlay.

It also adds a new marker setting `Overlay Content` which defines what content to render when hovering over a marker's feature.

Resolves #10 