### PR TITLE
Fix bounds bug

### DIFF
--- a/resources/ext.simplemaps/simplemaps.js
+++ b/resources/ext.simplemaps/simplemaps.js
@@ -698,7 +698,9 @@
 				);
 				legend.addTo(simpleMap)
 			}
-			simpleMap.fitBounds(bounds);
+			try {
+				simpleMap.fitBounds(bounds);
+			} catch {}
 		})
 	}
 	var localSettingSets = loadLocalSettingSets();


### PR DESCRIPTION
This PR fixes a bug where a map with no markers would break rendering for all maps on the page.